### PR TITLE
Bugfix/fix promise chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "axios-logger": "^2.5.0"
     },
     "jest": {
-        "testURL": "http://localhost/"
+        "testURL": "http://localhost/",
+        "testEnvironment": "node"
     },
     "directories": {
         "test": "test"

--- a/src/churchtoolsClient.js
+++ b/src/churchtoolsClient.js
@@ -329,9 +329,10 @@ class ChurchToolsClient {
                     return res;
                 })
                 .catch(e => {
-                    logError(e);
+                    logError(e).catch(() => {}); // catch is needed as logError can return a rejected promise
                     this.loginRunning = false;
                     this.currentLoginPromise = undefined;
+                    throw e;
                 });
         }
         return this.currentLoginPromise;

--- a/test/churchtoolsClient.test.js
+++ b/test/churchtoolsClient.test.js
@@ -4,7 +4,7 @@ test('should fail for invalid credentials', done => {
     let ctc = new ChurchToolsClient('https://review.church.tools', 'foobar', true);
     //ctc.setRateLimitInterceptor();
     //ctc.setCookieJar(axiosCookieJarSupport.default, new tough.CookieJar());
-    ctc.get('/contactlabels', {}, false, false)
+    ctc.get('/contactlabels')
         .then(result => {
             expect(true).toBe(false);
             done();

--- a/test/churchtoolsClient.test.js
+++ b/test/churchtoolsClient.test.js
@@ -1,0 +1,19 @@
+import {ChurchToolsClient} from '../src/churchtoolsClient';
+
+test('should fail for invalid credentials', done => {
+    let ctc = new ChurchToolsClient('https://review.church.tools', 'foobar', true);
+    //ctc.setRateLimitInterceptor();
+    //ctc.setCookieJar(axiosCookieJarSupport.default, new tough.CookieJar());
+    ctc.get('/contactlabels', {}, false, false)
+        .then(result => {
+            expect(true).toBe(false);
+            done();
+        })
+        .catch(error => {
+            if (error.matcherResult) {
+                throw error;
+            }
+            expect(error.statusText).toBe('Unauthorized');
+            done();
+        });
+});


### PR DESCRIPTION
Im Fall von falschem Login-Token (unauthorized) wurde die Promise-Chain nicht richtig fortgeführt. Es fehlte ein Re-throw an einer Stelle.

Außerdem gab es eine unhandled Promise Rejection: logError returnt eine Promise, die für bestimmte Loglevel rejected wird 🤦 . Das wird jetzt abgefangen.