### PR TITLE
Bugfix/axios cookie jar no other http agent

### DIFF
--- a/examples/Node.js/index.js
+++ b/examples/Node.js/index.js
@@ -1,8 +1,13 @@
 
 // Settings: Please set accordingly to run this demo.
-const BASEURL = 'https://demo.church.tools';
-const USERNAME = 'please-replace';
-const PASSWORD = 'please-replace';
+const SETTINGS = {
+    BASEURL: 'https://demo.church.tools',
+    USERNAME: 'please-replace',
+    PASSWORD: 'please-replace',
+    // if TOKEN is set, the TOKEN is used to log in instead of USERNAME/PASSWORD
+    //TOKEN: 'please-replace'
+};
+
 // End of Settings
 
 const { churchtoolsClient, activateLogging, LOG_LEVEL_INFO, errorHelper } = require('@churchtools/churchtools-client');
@@ -11,7 +16,7 @@ const tough = require('tough-cookie');
 
 function initChurchToolsClient() {
     churchtoolsClient.setCookieJar(axiosCookieJarSupport.wrapper, new tough.CookieJar());
-    churchtoolsClient.setBaseUrl(BASEURL);
+    churchtoolsClient.setBaseUrl(SETTINGS.BASEURL);
     // Logging can be activated to either LOG_LEVEL_NONE (no logging at all, default),
     // LOG_LEVEL_DEBUG (outputs every request and response including request/response data)
     // LOG_LEVEL_INFO (outputs every request and response, but only method and URL) or
@@ -19,16 +24,31 @@ function initChurchToolsClient() {
     activateLogging(LOG_LEVEL_INFO);
 }
 
-function login(username, password) {
+//
+function login() {
+    // if we have a login token, we use this
+    if (SETTINGS.TOKEN) {
+        churchtoolsClient.setUnauthorizedInterceptor(SETTINGS.TOKEN);
+        // we call /api/contactlabels here, as an example. Any api call will trigger an automatic login with TOKEN
+        return churchtoolsClient.get('/contactlabels')
+            .then(() => {
+                console.log('Login with token successful.');
+                return true;
+            });
+    }
+
+    // no login token => use username / password
     return churchtoolsClient.post('/login', {
-        username,
-        password
+        username: SETTINGS.USERNAME,
+        password: SETTINGS.PASSWORD
+    }).then(() => {
+        console.log('Login successful.');
+        return true;
     });
 }
 
 initChurchToolsClient();
-login(USERNAME, PASSWORD).then(() => {
-    console.log('Login successful.');
+login().then(() => {
     return churchtoolsClient.get('/whoami').then(whoAmI => {
         console.log(`Hello ${whoAmI.firstName}!`);
     });

--- a/examples/Node.js/package.json
+++ b/examples/Node.js/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "axios-cookiejar-support": "^4.0.0",
-    "@churchtools/churchtools-client": "^1.2.0",
+    "@churchtools/churchtools-client": "^1.2.3",
     "tough-cookie": "^4.0.0"
   }
 }

--- a/src/churchtoolsClient.js
+++ b/src/churchtoolsClient.js
@@ -350,6 +350,8 @@ class ChurchToolsClient {
                     };
                 }
                 config.cancelToken = this.getCancelToken();
+                config.httpAgent = undefined;
+                config.httpsAgent = undefined;
                 this.ax
                     .request(config)
                     .then(response => {


### PR DESCRIPTION
Löst das Problem mit der axios-cookie-jar Fehlermeldung `axios-cookiejar-support does not support for use with other http(s).Agent.'`

=> anschließend bitte eine Version 1.2.3 bauen!