### PR TITLE
set console.log as logger

### DIFF
--- a/src/logging.js
+++ b/src/logging.js
@@ -68,7 +68,8 @@ const logMessage = (message, message2) => {
 const getAxiosLoggerConfig = () => {
     return {
         prefixText: 'ChurchToolsClient',
-        data: logLevel >= LOG_LEVEL_DEBUG
+        data: logLevel >= LOG_LEVEL_DEBUG,
+        logger: console.log
     };
 };
 


### PR DESCRIPTION
Set console.log in getAxiosLogerConfig() as logger explicitly. When a project is overriding console.log (e.g. to write the logs into a file), axiosLogger will still use the old (normal) console.log method, since it has it saved in a variable.
With this change we give always the current definition of console.log to the logger. 