### PR TITLE
fix FormData headers for POSTs on Node.js

### DIFF
--- a/src/churchtoolsClient.ts
+++ b/src/churchtoolsClient.ts
@@ -369,7 +369,7 @@ class ChurchToolsClient {
     }
 
     post<ResponseType>(uri: string, data: Params = {}, options: PostOptions = {}) {
-        const isNodeJsFormData = (data && data.constructor && data.constructor.name === 'FormData');
+        const isNodeJsFormData = data && data.constructor && data.constructor.name === 'FormData';
         // FormData will be sent as multipart/form-data and the CT server requires a CSRF token for such a request
         // React-Native mangles the constructor.name. Therefore, another check must be applied to react-native
         const needsCsrfToken =
@@ -412,7 +412,7 @@ class ChurchToolsClient {
                                 ...config.headers,
                                 // @ts-ignore
                                 ...data.getHeaders(),
-                                'Content-Type': 'multipart/form-data'
+                                'Content-Type': 'multipart/form-data',
                             };
                         }
                         config.signal = this.getAbortSignal(options.abortController, options.timeout);

--- a/src/churchtoolsClient.ts
+++ b/src/churchtoolsClient.ts
@@ -369,10 +369,11 @@ class ChurchToolsClient {
     }
 
     post<ResponseType>(uri: string, data: Params = {}, options: PostOptions = {}) {
+        const isNodeJsFormData = (data && data.constructor && data.constructor.name === 'FormData');
         // FormData will be sent as multipart/form-data and the CT server requires a CSRF token for such a request
-        // React-Native mangles the constructor.name. Therefore another check must be applied to react-native
+        // React-Native mangles the constructor.name. Therefore, another check must be applied to react-native
         const needsCsrfToken =
-            (!globalThis.FormData && data && data.constructor && data.constructor.name === 'FormData') || // Node-JS
+            isNodeJsFormData || // Node-JS
             (globalThis.FormData && data instanceof FormData); // browser/react-native
         const needsAuthentication = options.needsAuthentication;
 
@@ -402,6 +403,16 @@ class ChurchToolsClient {
                             config.headers = {
                                 ...config.headers,
                                 'CSRF-Token': this.csrfToken ?? '',
+                            };
+                        }
+                        // Axios 0.24.0 in Node.js does not automatically set the Content-Type header for FormData
+                        // objects, nor does it set the boundary for the multipart/form-data content type.
+                        if (isNodeJsFormData) {
+                            config.headers = {
+                                ...config.headers,
+                                // @ts-ignore
+                                ...data.getHeaders(),
+                                'Content-Type': 'multipart/form-data'
                             };
                         }
                         config.signal = this.getAbortSignal(options.abortController, options.timeout);


### PR DESCRIPTION
For multipart form-data POSTs, axios 0.24.0 (current dependency) does not automatically set the required headers (Content-Type, multipart boundary etc.) under node.js. Somehow the detection, that the data is of type FormData does not work in axios. So we have to fix this in our client by setting the headers explicitly.